### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ jobs:
         id: get_version
         run: echo ::set-env name=VERNEMQ_VERSION::$(cat image/version.txt)
       - name: Push
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           workdir: image
           buildargs: VERNEMQ_VERSION


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore